### PR TITLE
foundation: stage1 - gnutar: make build scripts executable

### DIFF
--- a/foundation/src/stages/stage1/gnutar/boot.nix
+++ b/foundation/src/stages/stage1/gnutar/boot.nix
@@ -56,6 +56,8 @@ in {
             rm tar.tar
             cd tar-${cfg.version}
 
+            chmod 0755 missing mkinstalldirs install-sh
+
             # Configure
             export CC="tcc -B ${stage1.tinycc.mes.libs.package}/lib"
             bash ./configure \


### PR DESCRIPTION
mescc-tools-extra's 'untar' tool doesn't set file modes at all, so scripts like `missing` are not immediately executable

Hydra failure log: https://hydra.aux-cache.dev/build/45/nixlog/1/tail

mescc-tools-extra's untar source (I think): https://github.com/oriansj/mescc-tools-extra/blob/master/untar.c#L139